### PR TITLE
Add support for the current version of php (8.1) and Laravel (9)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.1",
         "guzzlehttp/guzzle": "~6.2|~7.0",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0",
         "wayforpay/php-sdk": "^1.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5|^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^3.5|^4.0|^5.0|^6.0|^7.0",
         "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi!

Great package, but I need to use it for a newer version of Laravel.

I changed the supported versions and checked on the project, everything works for the newer version.